### PR TITLE
BinaryProvider is not required.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,10 @@ authors = ["Andrei Zhabinski <andrei.zhabinski@gmail.com>"]
 version = "0.1.0"
 
 [deps]
-BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 librdkafka_jll = "7943bfb0-7437-5acd-a008-22777931c7aa"
 
 [compat]
 julia = "1.3"
-BinaryProvider = "0.5.0"
 librdkafka_jll = "1.5"
 
 [extras]


### PR DESCRIPTION
BinaryProvider is no longer required. I think we should re-register, since it's annoying to have a BP depdendency. 