### PR TITLE
Fix delivery & error callbacks and polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,27 @@ msg = nothing
 msg = nothing
 ```
 where `nothing` means that there were no new messages in that polling interval while `Message(...)` is actual message we sent from producer.
+
+### Error handling
+
+Add the `err_cb` argument to either KafkaConsumer or KafkaProducer.
+
+```
+c = KafkaConsumer("localhost:9092", "my-consumer-group", err_cb=(err::Int, reason::String) -> throw(error(reason)))
+```
+
+### Delivery reports
+
+Add the `dr_cb` argument to a KafkaProducer.
+
+```
+p = KafkaProducer("localhost:9092", dr_cb=msg -> if msg.err != 0 throw(error("Delivery failed") end))
+```
+
+### Seeking
+
+```
+c = KafkaConsumer("localhost:9092", "my-consumer-group")
+RDKafka.seek(c, timestamp_ms, timeout_ms)
+```
+

--- a/src/RDKafka.jl
+++ b/src/RDKafka.jl
@@ -4,7 +4,7 @@ using librdkafka_jll
 export KafkaProducer,
     KafkaConsumer,
     KafkaClient,
-    # produce,
+    produce,
     subscribe,
     seek,
     poll

--- a/src/client.jl
+++ b/src/client.jl
@@ -60,7 +60,7 @@ function KafkaClient(typ::Integer, conf::Dict=Dict(); dr_cb=nothing, err_cb=noth
     if err_cb != nothing
         ERROR_CALLBACKS[rk] = err_cb
     end
-    @async while polling
+    Threads.@spawn while polling
         kafka_poll(rk, 0)
         sleep(1)
     end

--- a/src/client.jl
+++ b/src/client.jl
@@ -60,7 +60,7 @@ function KafkaClient(typ::Integer, conf::Dict=Dict(); dr_cb=nothing, err_cb=noth
     if err_cb != nothing
         ERROR_CALLBACKS[rk] = err_cb
     end
-    Threads.@spawn while polling
+    @async while polling
         kafka_poll(rk, 0)
         sleep(1)
     end

--- a/src/client.jl
+++ b/src/client.jl
@@ -13,16 +13,17 @@ function delivery_callback(rk::Ptr{Cvoid}, rkmessage::Ptr{CKafkaMessage}, opaque
         cb(msg)
     end
 end
-delivery_callback_c = @cfunction(delivery_callback, Cvoid, (Ptr{Cvoid}, Ptr{CKafkaMessage}, Ptr{Cvoid}))
 
 
+# error callbacks are called with the arguments (err::Int, reason::String)
 function error_callback(rk::Ptr{Cvoid}, err::Cint, reason::Ptr{Cchar}, opaque::Ptr{Cvoid})::Cvoid
-    # TODO: implement
-    @warn "Error callback is not implemented"
+    reason = unsafe_string(reason)
+    if haskey(ERROR_CALLBACKS, rk)
+        cb = ERROR_CALLBACKS[rk]
+        cb(err, reason)
+    end
 end
-error_callback_c = @cfunction(error_callback, Cvoid, (Ptr{Cvoid}, Cint, Ptr{Cvoid}, Ptr{Cvoid}))
-const ERROR_CALLBACKS = Dict{Ptr, Function}
-
+const ERROR_CALLBACKS = Dict{Ptr, Function}()
 
 
 mutable struct KafkaClient
@@ -33,23 +34,21 @@ end
 
 
 function KafkaClient(typ::Integer, conf::Dict=Dict(); dr_cb=nothing, err_cb=nothing)
-    # TODO: add options for callbacks, creata a task calling kafka_poll(rk, timeout) every 1 second
     c_conf = kafka_conf_new()
     for (k, v) in conf
         kafka_conf_set(c_conf, string(k), string(v))
     end
+    # set callbacks in config before creating rk
     if dr_cb != nothing
-        # set callback in config before creating rk
-        kafka_conf_set_dr_msg_cb(c_conf, delivery_callback_c)
+        kafka_conf_set_dr_msg_cb(c_conf, @cfunction(delivery_callback, Cvoid, (Ptr{Cvoid}, Ptr{CKafkaMessage}, Ptr{Cvoid})))
     end
     if err_cb != nothing
-        kafka_conf_set_error_cb(c_conf, error_callback_c)
+        kafka_conf_set_error_cb(c_conf, @cfunction(error_callback, Cvoid, (Ptr{Cvoid}, Cint, Ptr{Cchar}, Ptr{Cvoid})))
     end
     rk = kafka_new(c_conf, Cint(typ))
     client = KafkaClient(conf, typ, rk)
     # seems like `kafka_destroy` also destroys its config, so we don't attempt it twice
     finalizer(client -> kafka_destroy(rk), client)
-    Timer(t -> kafka_poll(rk, 100), 1; interval=1)
     if dr_cb != nothing
         # set Julia callback after rk is created
         DELIVERY_CALLBACKS[rk] = dr_cb

--- a/src/client.jl
+++ b/src/client.jl
@@ -61,7 +61,7 @@ function KafkaClient(typ::Integer, conf::Dict=Dict(); dr_cb=nothing, err_cb=noth
         ERROR_CALLBACKS[rk] = err_cb
     end
     @async while polling
-        kafka_poll(rk, 1000)
+        kafka_poll(rk, 0)
         sleep(1)
     end
     return client

--- a/src/consumer.jl
+++ b/src/consumer.jl
@@ -21,7 +21,7 @@ end
 function KafkaConsumer(conf::Dict; dr_cb=nothing, err_cb=nothing)
     @assert haskey(conf, "bootstrap.servers") "`bootstrap.servers` should be specified in conf"
     @assert haskey(conf, "group.id") "`group.id` should be specified in conf"
-    client = KafkaClient(KAFKA_TYPE_CONSUMER, conf; dr_cb, err_cb)
+    client = KafkaClient(KAFKA_TYPE_CONSUMER, conf; dr_cb=dr_cb, err_cb=err_cb)
     parlist = PartitionList()
     return KafkaConsumer(client, parlist)
 end
@@ -30,7 +30,7 @@ end
 function KafkaConsumer(bootstrap_servers::String, group_id::String, conf::Dict=Dict(); dr_cb=nothing, err_cb=nothing)
     conf["bootstrap.servers"] = bootstrap_servers
     conf["group.id"] = group_id
-    return KafkaConsumer(conf; dr_cb, err_cb)
+    return KafkaConsumer(conf; dr_cb=dr_cb, err_cb=err_cb)
 end
 
 

--- a/src/consumer.jl
+++ b/src/consumer.jl
@@ -18,19 +18,19 @@ mutable struct KafkaConsumer
 end
 
 
-function KafkaConsumer(conf::Dict)
+function KafkaConsumer(conf::Dict; dr_cb=nothing, err_cb=nothing)
     @assert haskey(conf, "bootstrap.servers") "`bootstrap.servers` should be specified in conf"
     @assert haskey(conf, "group.id") "`group.id` should be specified in conf"
-    client = KafkaClient(KAFKA_TYPE_CONSUMER, conf)
+    client = KafkaClient(KAFKA_TYPE_CONSUMER, conf; dr_cb, err_cb)
     parlist = PartitionList()
     return KafkaConsumer(client, parlist)
 end
 
 
-function KafkaConsumer(bootstrap_servers::String, group_id::String, conf::Dict=Dict())
+function KafkaConsumer(bootstrap_servers::String, group_id::String, conf::Dict=Dict(); dr_cb=nothing, err_cb=nothing)
     conf["bootstrap.servers"] = bootstrap_servers
     conf["group.id"] = group_id
-    return KafkaConsumer(conf)
+    return KafkaConsumer(conf; dr_cb, err_cb)
 end
 
 

--- a/src/producer.jl
+++ b/src/producer.jl
@@ -8,14 +8,6 @@ end
 
 function KafkaProducer(conf::Dict; dr_cb=nothing, err_cb=nothing)
     kc = KafkaClient(KAFKA_TYPE_PRODUCER, conf; dr_cb=dr_cb, err_cb=err_cb)
-    if dr_cb != nothing || err_cb != nothing
-        @async begin
-            while true
-                kafka_poll(kc.rk, 1000)
-                sleep(1)
-            end
-        end
-    end
     return KafkaProducer(kc, Dict())
 end
 

--- a/src/producer.jl
+++ b/src/producer.jl
@@ -8,6 +8,14 @@ end
 
 function KafkaProducer(conf::Dict; dr_cb=nothing, err_cb=nothing)
     kc = KafkaClient(KAFKA_TYPE_PRODUCER, conf; dr_cb=dr_cb, err_cb=err_cb)
+    if dr_cb != nothing || err_cb != nothing
+        @async begin
+            while true
+                kafka_poll(kc.rk, 1000)
+                sleep(1)
+            end
+        end
+    end
     return KafkaProducer(kc, Dict())
 end
 

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -201,9 +201,6 @@ function kafka_subscribe(rk::Ptr{Cvoid}, rkparlist::Ptr{CKafkaTopicPartitionList
     if errcode != 0
         error("Subscription failed with error $errcode")
     end
-    # since we use rd_kafka_consumer_poll, redirect the rd_kafka_poll() queue to the consumer queue.
-    ccall((:rd_kafka_poll_set_consumer, librdkafka), Cint,
-        (Ptr{Cvoid},), rk)
 end
 
 

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -134,7 +134,7 @@ function produce(rkt::Ptr{Cvoid}, partition::Integer,
     if errcode != 0
         #error("Produce request failed with error code (unix): $errcode")
         ## errno is c global var
-	errnr = unsafe_load(cglobal(:errno, Int32))
+    	errnr = unsafe_load(cglobal(:errno, Int32))
         errmsg = unsafe_string(ccall(:strerror, Cstring, (Int32,), errnr))
         error("Produce request failed with error code: $errmsg")  
     end
@@ -201,6 +201,9 @@ function kafka_subscribe(rk::Ptr{Cvoid}, rkparlist::Ptr{CKafkaTopicPartitionList
     if errcode != 0
         error("Subscription failed with error $errcode")
     end
+    # since we use rd_kafka_consumer_poll, redirect the rd_kafka_poll() queue to the consumer queue.
+    ccall((:rd_kafka_poll_set_consumer, librdkafka), Cint,
+        (Ptr{Cvoid},), rk)
 end
 
 
@@ -261,3 +264,4 @@ end
 function kafka_message_destroy(msg_ptr::Ptr{CKafkaMessage})
     ccall((:rd_kafka_message_destroy, librdkafka), Cvoid, (Ptr{Cvoid},), msg_ptr)
 end
+5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,3 +18,13 @@ RDKafka.kafka_conf_set(conf, "socket.keepalive.enable", "true")
 
 RDKafka.kafka_conf_destroy(conf)
 @test true # No exceptions
+
+@testset "Verify error callback is called" begin
+  conf = Dict()
+  conf["bootstrap.servers"] = "bad"
+  ch = Channel(1)
+  RDKafka.KafkaProducer(conf; err_cb=(err, reason) -> begin
+    push!(ch, err)
+  end)
+  @test take!(ch) == -193
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,11 +20,11 @@ RDKafka.kafka_conf_destroy(conf)
 @test true # No exceptions
 
 @testset "Verify error callback is called" begin
-  conf = Dict()
-  conf["bootstrap.servers"] = "bad"
-  ch = Channel(1)
-  RDKafka.KafkaProducer(conf; err_cb=(err, reason) -> begin
-    push!(ch, err)
-  end)
-  @test take!(ch) == -193
+    conf = Dict()
+    conf["bootstrap.servers"] = "bad"
+    ch = Channel(1)
+    RDKafka.KafkaProducer(conf; err_cb=(err, reason) -> begin
+        push!(ch, err)
+    end)
+    @test take!(ch) == -193
 end


### PR DESCRIPTION
- Fix delivery cb and implement error callback
- Add @async polling Task if callbacks are used
- Add @test for error callback
- Document callbacks and `seek()`
- Re-export `produce()`
