### PR TITLE
Fixes segfault on SIGINT

### DIFF
--- a/src/consumer.jl
+++ b/src/consumer.jl
@@ -7,7 +7,6 @@ end
 function PartitionList()
     ptr = kafka_topic_partition_list_new()
     parlist = PartitionList(ptr)
-    finalizer(parlist -> kafka_topic_partition_list_destroy(ptr), parlist)
     return parlist
 end
 
@@ -86,5 +85,10 @@ function poll(::Type{K}, ::Type{P}, c::KafkaConsumer, timeout::Int=1000) where {
     end
 end
 
+function Base.close(c::KafkaConsumer)
+    kafka_topic_partition_list_destroy(c.parlist.rkparlist)
+    kafka_consumer_close(c.client.rk)
+    kafka_destroy(c.client.rk)
+end
 
 poll(c::KafkaConsumer, timeout::Int=1000) = poll(Vector{UInt8}, Vector{UInt8}, c, timeout)

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -66,6 +66,10 @@ function kafka_destroy(rk::Ptr{Cvoid})
 end
 
 
+function kafka_consumer_close(rk::Ptr{Cvoid})
+    ccall((:rd_kafka_consumer_close, librdkafka), Cvoid, (Ptr{Cvoid},), rk)
+end
+
 ## rd_kafka_topic_conf_t
 
 function kafka_topic_conf_new()


### PR DESCRIPTION
* Removed all `finalizer` call because for what I know it is hard to say in what orders finalizer get called
 and this may cause problems with the correct order of api call expected by librdkafka.

* added `kafka_consumer_close`

* removed timer `kafka_poll` from `KafkaClient` 
