### PR TITLE
Update librdkafka_jll to 2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ librdkafka_jll = "7943bfb0-7437-5acd-a008-22777931c7aa"
 
 [compat]
 julia = "1.6"
-librdkafka_jll = "1.8.2"
+librdkafka_jll = "2.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RDKafka"
 uuid = "43e2f499-f4c7-585f-8317-cbc2d9c3bf8f"
 authors = ["Andrei Zhabinski <andrei.zhabinski@gmail.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 librdkafka_jll = "7943bfb0-7437-5acd-a008-22777931c7aa"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,15 +1,13 @@
 using RDKafka
 using Test
 
-a = RDKafka.rd_kafka_version() # 0x010802ff for 1.8.2
+a = RDKafka.rd_kafka_version() # 0x020002ff for 2.0.2
 # verify the major and minor. Any change to these should be reflected
 # by a change in Project.toml
-@test (a & 0x01000000) == 0x01000000
-@test (a & 0x00080000) == 0x00080000
-@test (a & 0x00000200) == 0x00000200
+@test (a & 0xff000000) == 0x02000000
+@test (a & 0x00ff0000) == 0x00000000
 
-
-conf =  RDKafka.kafka_conf_new()
+conf = RDKafka.kafka_conf_new()
 @test RDKafka.kafka_conf_get(conf, "socket.keepalive.enable") == "false"
 RDKafka.kafka_conf_set(conf, "socket.keepalive.enable", "true")
 @test RDKafka.kafka_conf_get(conf, "socket.keepalive.enable") == "true"


### PR DESCRIPTION
This updates the package to use a more recent version the rdkafka C library (you can see release notes [here](https://github.com/confluentinc/librdkafka/releases) - the "breaking" changes relate to some differences due to the (optional) OpenSSL 3.0 support, not the C interface).

Note also, I have updated the build script for librdkafka_jll to include SASL authentication support. Currently the linked binary will segfault when we attempt to use it - this is a critical use case for us.