### PR TITLE
Handle cases where key or payload are subtypes of Integer

### DIFF
--- a/src/client.jl
+++ b/src/client.jl
@@ -105,8 +105,8 @@ Base.convert(::Type{String}, data::Vector{UInt8}) = String(data)
 function Message{K,P}(c_msg::CKafkaMessage) where {K,P}
     topic = KafkaTopic(Dict(), "<unkown>", c_msg.rkt)
     if c_msg.err == 0
-        key = convert(K, unsafe_load_array(c_msg.key, c_msg.key_len))
-        payload = convert(P, unsafe_load_array(c_msg.payload, c_msg.len))
+        key = _frombytestream(K, unsafe_load_array(c_msg.key, c_msg.key_len))
+        payload = _frombytestream(P, unsafe_load_array(c_msg.payload, c_msg.len))
         return Message(Int(c_msg.err), topic, c_msg.partition, key, payload, c_msg.offset)
     else
         return Message{K,P}(Int(c_msg.err), topic, c_msg.partition, nothing, nothing, c_msg.offset)

--- a/src/producer.jl
+++ b/src/producer.jl
@@ -23,6 +23,20 @@ function Base.show(io::IO, p::KafkaProducer)
 end
 
 
+function produce(kt::KafkaTopic, partition::Integer, key, payload::Integer)
+    # Converting an Integer type to a Vector{UInt8} needs to be done through reinterpret
+    # Additionally, convert from host endianness to network endianness
+    produce(kt, partition, key, reinterpret(UInt8, [hton(payload)]))
+end
+
+
+function produce(kt::KafkaTopic, partition::Integer, key::Integer, payload)
+    # Converting an Integer type to a Vector{UInt8} needs to be done through reinterpret
+    # Additionally, convert from host endianness to network endianness
+    produce(kt, partition, reinterpret(UInt8, [hton(key)]), payload)
+end
+
+
 function produce(kt::KafkaTopic, partition::Integer, key, payload)
     # produce(kt.rkt, partition, convert(Vector{UInt8}, key), convert(Vector{UInt8}, payload))
     produce(kt.rkt, partition, Vector{UInt8}(key), Vector{UInt8}(payload))

--- a/src/producer.jl
+++ b/src/producer.jl
@@ -23,23 +23,9 @@ function Base.show(io::IO, p::KafkaProducer)
 end
 
 
-function produce(kt::KafkaTopic, partition::Integer, key, payload::Integer)
-    # Converting an Integer type to a Vector{UInt8} needs to be done through reinterpret
-    # Additionally, convert from host endianness to network endianness
-    produce(kt, partition, key, reinterpret(UInt8, [hton(payload)]))
-end
-
-
-function produce(kt::KafkaTopic, partition::Integer, key::Integer, payload)
-    # Converting an Integer type to a Vector{UInt8} needs to be done through reinterpret
-    # Additionally, convert from host endianness to network endianness
-    produce(kt, partition, reinterpret(UInt8, [hton(key)]), payload)
-end
-
-
 function produce(kt::KafkaTopic, partition::Integer, key, payload)
     # produce(kt.rkt, partition, convert(Vector{UInt8}, key), convert(Vector{UInt8}, payload))
-    produce(kt.rkt, partition, Vector{UInt8}(key), Vector{UInt8}(payload))
+    produce(kt.rkt, partition, _tobytestream(key), _tobytestream(payload))
 end
 
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -7,3 +7,19 @@ function unsafe_load_array(p::Ptr{T}, len::Integer) where T
     end
     return a
 end
+
+# Internal method to convert a key/payload to a bytestream for Kafka
+# Numeric types can be represented as a byte stream using hton and reinterpret.
+# We will need to do the opposite on the consumer side to convert bac
+_tobytestream(o::Number) = reinterpret(UInt8, [hton(payload)])
+_tobytestream(o::Vector{UInt8}) = o
+_tobytestream(o::AbstractString) = Vector{UInt8}(o)
+_tobytestream(::Nothing) = [UInt8(0)]
+# The generic version will convert to String first. This is used for symbols and any complex object.
+# Callers would be better off using JSON or byte stream instead
+_tobytestream(o) = _tobytestream(string(o))
+
+# Internal method to convert a byte stream to a Julia object
+_frombytestream(::Type{T}, stream::Vector{UInt8}) where {T<:Number} = ntoh(reinterpret(T, stream)[1])
+_frombytestream(::Type{Vector{UInt8}}, stream::Vector{UInt8}) = stream
+_frombytestream(::Type{T}, stream::Vector{UInt8}) where {T<:AbstractString}= T(stream)


### PR DESCRIPTION
Integer values cannot be converted directly to Vector{UInt8}; it requires `reinterpret` and `hton`. This MR handles that.

We have separate methods for `key` and `payload` so that it can handle all three cases where either one of key or payload are Integers, or both are Integers.