### PR TITLE
Add producer flags parameter; fix CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
         os:
           - ubuntu-latest
         arch:
-          - x86
+          - x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1

--- a/src/producer.jl
+++ b/src/producer.jl
@@ -28,6 +28,10 @@ function produce(kt::KafkaTopic, partition::Integer, key, payload)
     produce(kt.rkt, partition, _tobytestream(key), _tobytestream(payload))
 end
 
+function produce(kt::KafkaTopic, partition::Integer, key, payload, flags)
+    produce(kt.rkt, partition, _tobytestream(key), _tobytestream(payload), flags)
+end
+
 
 function produce(p::KafkaProducer, topic::String, partition::Integer, key, payload)
     if !haskey(p.topics, topic)
@@ -36,6 +40,17 @@ function produce(p::KafkaProducer, topic::String, partition::Integer, key, paylo
     produce(p.topics[topic], partition, key, payload)
 end
 
+function produce(p::KafkaProducer, topic::String, partition::Integer, key, payload, flags)
+    if !haskey(p.topics, topic)
+        p.topics[topic] = KafkaTopic(p.client, topic, Dict())
+    end
+    produce(p.topics[topic], partition, key, payload, flags)
+end
+
+function produce(p::KafkaProducer, topic::String, key, payload, flags)
+    partition_unassigned = -1
+    produce(p, topic, partition_unassigned, key, payload, flags)
+end
 
 function produce(p::KafkaProducer, topic::String, key, payload)
     partition_unassigned = -1

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -274,4 +274,3 @@ end
 function kafka_message_destroy(msg_ptr::Ptr{CKafkaMessage})
     ccall((:rd_kafka_message_destroy, librdkafka), Cvoid, (Ptr{Cvoid},), msg_ptr)
 end
-5

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -117,16 +117,29 @@ function kafka_poll(rk::Ptr{Cvoid}, timeout::Integer)
     
 end
 
+# Produce message flags
+# NOTE: RD_KAFKA_MSG_F_FREE and RD_KAFKA_MSG_F_COPY are mutually exclusive
+#
+const RD_KAFKA_MSG_F_FREE = Cint(1)
+const RD_KAFKA_MSG_F_COPY = Cint(2)
+const RD_KAFKA_MSG_F_BLOCK = Cint(4)
+const RD_KAFKA_MSG_F_PARTITION = Cint(8)
+
 
 function produce(rkt::Ptr{Cvoid}, partition::Integer,
-                 key::Vector{UInt8}, payload::Vector{UInt8})
-    flags = Cint(0)
+    key::Vector{UInt8}, payload::Vector{UInt8})
+    produce(rkt, partition, key, payload, [])
+end
+
+
+function produce(rkt::Ptr{Cvoid}, partition::Integer,
+                 key::Vector{UInt8}, payload::Vector{UInt8}, flags::Vector{Cint})
     errcode = ccall((:rd_kafka_produce, librdkafka), Cint,
                     (Ptr{Cvoid}, Int32, Cint,
                      Ptr{Cvoid}, Csize_t,
                      Ptr{Cvoid}, Csize_t,
                      Ptr{Cvoid}),
-                    rkt, Int32(partition), flags,
+                    rkt, Int32(partition), reduce(|, flags, init=Cint(0)),
                     pointer(payload), length(payload),
                     pointer(key), length(key),
                     C_NULL)   

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,11 @@
 using RDKafka
 using Test
 
-a = RDKafka.rd_kafka_version() # 0x020002ff for 2.0.2
+a = RDKafka.rd_kafka_version() # 0x020300ff for 2.3.0
 # verify the major and minor. Any change to these should be reflected
 # by a change in Project.toml
 @test (a & 0xff000000) == 0x02000000
-@test (a & 0x00ff0000) == 0x00000000
+@test (a & 0x00ff0000) == 0x00030000
 
 conf = RDKafka.kafka_conf_new()
 @test RDKafka.kafka_conf_get(conf, "socket.keepalive.enable") == "false"


### PR DESCRIPTION
This PR adds the ability to pass flags that modify the behaviour of a `produce()` call; see https://docs.confluent.io/platform/current/clients/librdkafka/html/rdkafka_8h.html#ae24d8ebf1ea15ed8ea0ea40f74662736

Originally the flags were hard-coded to `Cint(0)` and not configurable by the user.

I also made some small changes to the CI and test scripts, as the version of `librdkafka_jll` has been updated and the Actions were failing with `libcrypt.so` linking errors because they were using 32-bit libraries on 64-bit Ubuntu.